### PR TITLE
Make ICanvasRenderer inherit from IDisposable

### DIFF
--- a/Quill/ICanvasRenderer.cs
+++ b/Quill/ICanvasRenderer.cs
@@ -1,15 +1,14 @@
-﻿using Prowl.Vector;
+﻿using System;
+using Prowl.Vector;
 using System.Collections.Generic;
 
 namespace Prowl.Quill
 {
-    public interface ICanvasRenderer
+    public interface ICanvasRenderer : IDisposable
     {
         public object CreateTexture(uint width, uint height);
         public Vector2Int GetTextureSize(object texture);
         public void SetTextureData(object texture, IntRect bounds, byte[] data);
         public void RenderCalls(Canvas canvas, IReadOnlyList<DrawCall> drawCalls);
-
-        public void Dispose();
     }
 }


### PR DESCRIPTION
Tiny change since this bugged me when I was implementing ICanvasRenderer.
This allows using statements and other code designed for IDisposables to work.