### PR TITLE
Remove empty draw call from the start of the draw call list

### DIFF
--- a/Quill/Canvas.cs
+++ b/Quill/Canvas.cs
@@ -174,7 +174,7 @@ namespace Prowl.Quill
             }
         }
 
-        public IReadOnlyList<DrawCall> DrawCalls => _drawCalls.Where(d => d.ElementCount != 0).ToList();
+        public IReadOnlyList<DrawCall> DrawCalls => _drawCalls.AsReadOnly();
         public IReadOnlyList<uint> Indices => _indices.AsReadOnly();
         public IReadOnlyList<Vertex> Vertices => _vertices.AsReadOnly();
         public Vector2 CurrentPoint => _currentSubPath != null && _currentSubPath.Points.Count > 0 ? CurrentPointInternal : Vector2.zero;

--- a/Quill/Canvas.cs
+++ b/Quill/Canvas.cs
@@ -233,7 +233,6 @@ namespace Prowl.Quill
         {
             _drawCalls.Clear();
             _textureStack.Clear();
-            AddDrawCmd();
 
             _indices.Clear();
             _vertices.Clear();
@@ -464,9 +463,6 @@ namespace Prowl.Quill
 
         public void AddVertex(Vertex vertex)
         {
-            if (_drawCalls.Count == 0)
-                return;
-
             if (_globalAlpha != 1.0f)
                 vertex.a = (byte)(vertex.a * _globalAlpha);
 
@@ -487,9 +483,6 @@ namespace Prowl.Quill
         public void AddTriangle(int v1, int v2, int v3) => AddTriangle((uint)v1, (uint)v2, (uint)v3);
         public void AddTriangle(uint v1, uint v2, uint v3)
         {
-            if (_drawCalls.Count == 0)
-                return;
-
             // Add the triangle indices to the list
             _indices.Add(v1);
             _indices.Add(v2);
@@ -501,7 +494,9 @@ namespace Prowl.Quill
         private void AddTriangleCount(int count)
         {
             if (_drawCalls.Count == 0)
-                return;
+            {
+                AddDrawCmd();
+            }
 
             DrawCall lastDrawCall = _drawCalls[_drawCalls.Count - 1];
 

--- a/Quill/Canvas.cs
+++ b/Quill/Canvas.cs
@@ -512,8 +512,10 @@ namespace Prowl.Quill
 
             if (!isDrawStateSame)
             {
-                // If the texture or scissor state has changed, add a new draw call
-                AddDrawCmd();
+                // If draw state has changed and the last draw call has already been used, add a new draw call
+                if (lastDrawCall.ElementCount != 0)
+                    AddDrawCmd();
+
                 lastDrawCall = _drawCalls[_drawCalls.Count - 1];
                 lastDrawCall.Texture = _state.texture;
                 lastDrawCall.scissor = _state.scissor;


### PR DESCRIPTION
This PR is mergeable as is, but there is one major question I'd like to discuss first.

Does `AddDrawCmd()` have to be public? This being public means it's possible and valid for users to add empty draw calls to the draw call list. Additionally, after calling `AddDrawCmd()`, I would expect the `DrawCalls` property to reflect that the empty draw call has been added. Because the existing implementation filters these empty draw calls out, this currently is not the case.

I believe how draw calls are formed should be an internal implementation detail and users of the Canvas API can only get the resulting draw calls that are made as a result of interacting with the rest of the Canvas API. `AddDrawCmd()` being public allows users to interfere and impose additional constraints on how draw calls are handled.

I will revise my commits depending on whether `AddDrawCmd()` should be public or not. The commits currently assume that `AddDrawCmd()` needs to be public, but the first commit has an non-ideal implementation since it can potentially modify user added draw calls.